### PR TITLE
Enabled the possibility of choosing W-cycles instead of K-cycles. For…

### DIFF
--- a/sample_devel.ini
+++ b/sample_devel.ini
@@ -50,7 +50,7 @@ d0 mu factor: 1.0
 d1 global lattice: 4 4 4 4
 d1 local lattice: 2 2 2 4
 d1 block lattice: 2 2 2 2
-d1 preconditioner cycles: 1
+d1 preconditioner cycles: 3
 d1 post smooth iter: 2
 d1 block iter: 4
 d1 test vectors: 28
@@ -60,24 +60,8 @@ d1 mu factor: 1.0
 |--- depth 2 ----------------------------------|
 d2 global lattice: 2 2 2 2
 d2 local lattice: 1 1 1 2
-d2 block lattice: 1 1 1 1
-d2 preconditioner cycles: 1
-d2 post smooth iter: 2
-d2 block iter: 5
-d2 test vectors: 32
-d2 setup iter: 2
 d2 mu factor: 1.0
 
-|--- depth 3 ----------------------------------|
-d3 global lattice: 1 1 1 1
-d3 local lattice: 1 1 1 1
-d3 block lattice: 1 1 1 1
-d3 preconditioner cycles: 1
-d3 post smooth iter: 0
-d3 block iter: 0
-d3 test vectors: 0
-d3 setup iter: 0
-d3 mu factor: 8.0
 
 
 |----------------------------------------------|
@@ -111,10 +95,11 @@ coarse grid polyprec_d_solve: 2
 
 coarse grid local_polyprec_d: 3
 
-kcycle: 1
+kcycle: 1 # if turning on wcycle, don't turn kcycle off
 kcycle length: 5
 kcycle restarts: 2
 kcycle tolerance: 1E-1
+wcycle: 1
 
 |----------------------------------------------|
 |-------------- Wilson operator ---------------|

--- a/src/init.c
+++ b/src/init.c
@@ -1143,6 +1143,8 @@ void read_kcycle_data( FILE *in ) {
   read_parameter( &save_pt, "kcycle restarts:", "%d", 1, in, _DEFAULT_SET );
   save_pt = &(g.kcycle_tol); g.kcycle_tol = 1E-1;
   read_parameter( &save_pt, "kcycle tolerance:", "%le", 1, in, _DEFAULT_SET );
+  save_pt = &(g.wcycle); g.wcycle = 0;
+  read_parameter( &save_pt, "wcycle:", "%d", 1, in, _DEFAULT_SET );
 }
 
 void validate_parameters( int ls, level_struct *l ) {

--- a/src/main.h
+++ b/src/main.h
@@ -390,7 +390,7 @@
         **global_lattice, **local_lattice, **block_lattice, 
         *post_smooth_iter, *block_iter, *setup_iter, *ncycle,
         method, odd_even, rhs, propagator_coords[4],
-        interpolation, randomize, *num_eig_vect, num_coarse_eig_vect, kcycle, mixed_precision,
+        interpolation, randomize, *num_eig_vect, num_coarse_eig_vect, kcycle, wcycle, mixed_precision,
         restart, max_restart, kcycle_restart, kcycle_max_restart, coarse_iter, coarse_restart;
     double tol, coarse_tol, kcycle_tol, csw, rho, *relax_fac;
 #ifdef GCRODR

--- a/src/vcycle_generic.c
+++ b/src/vcycle_generic.c
@@ -107,10 +107,15 @@ void vcycle_PRECISION( vector_PRECISION phi, vector_PRECISION Dphi, vector_PRECI
           g.coarse_time -= MPI_Wtime();
         END_MASTER(threading)
         if ( l->level > 1 ) {
-          if ( g.kcycle )
-            fgmres_PRECISION( &(l->next_level->p_PRECISION), l->next_level, threading );
-          else
+          if ( g.kcycle ) {
+            if ( g.wcycle==1 ) {
+              vcycle_PRECISION( l->next_level->p_PRECISION.x, NULL, l->next_level->p_PRECISION.b, _NO_RES, l->next_level, threading );
+            } else {
+              fgmres_PRECISION( &(l->next_level->p_PRECISION), l->next_level, threading );
+            }
+          } else {
             vcycle_PRECISION( l->next_level->p_PRECISION.x, NULL, l->next_level->p_PRECISION.b, _NO_RES, l->next_level, threading );
+          }
         } else {
           if ( g.odd_even ) {
             if ( g.method == 6 ) {


### PR DESCRIPTION
… this, at the moment K-cycles data has to be allocated, mainly due to legacy allocation of matvecs being linked to the fgmres for the K-cycles